### PR TITLE
Adding RSS feed using @11ty/eleventy-plugin-rss

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,9 +1,11 @@
 const svgContents = require("eleventy-plugin-svg-contents");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
+const rssPlugin = require("@11ty/eleventy-plugin-rss");
 
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addPlugin(svgContents);
+  eleventyConfig.addPlugin(rssPlugin);
 
   eleventyConfig.addCollection("plugins", function(collectionApi) {
     return collectionApi.getFilteredByTag('plugins').sort((a, b) => {

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -7,7 +7,7 @@
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
     <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/assets/style.css">
-    <link rel="alternate" type="application/rss+xml" href="feed.xml" title="Atom feed">
+    <link rel="alternate" type="application/rss+xml" href="feed.xml" title="Plug11ty - The 11ty Plugin Repository">
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:creator" content="@brob" />
 <meta property="og:url" content="https://plug11ty.com/{{page.url}}" />

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -7,6 +7,7 @@
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
     <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/assets/style.css">
+    <link rel="alternate" type="application/rss+xml" href="feed.xml" title="Atom feed">
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:creator" content="@brob" />
 <meta property="og:url" content="https://plug11ty.com/{{page.url}}" />

--- a/feed.njk
+++ b/feed.njk
@@ -1,0 +1,32 @@
+---
+permalink: feed.xml
+eleventyExcludeFromCollections: true
+metadata:
+  title: plug11ty
+  url: https://plug11ty.com/
+  feedUrl: https://plug11ty.com/feed.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ metadata.title }}</title>
+  <link href="{{ metadata.feedUrl }}" rel="self"/>
+  <link href="{{ metadata.url }}"/>
+    <updated>{{ collections.all | rssLastUpdatedDate }}</updated>
+  <id>{{ metadata.url }}</id>
+  {%- if collections.plugins.length -%}
+    {%- for plugin in collections.plugins %}
+      {% set absolutePostUrl %}{{ plugin.url | url | absoluteUrl(metadata.url) }}{% endset %}
+      <entry>
+        <title>{{ plugin.data.title }}</title>
+        <summary>{{ plugin.data.description }}</summary>
+        <link href="{{ absolutePostUrl }}"/>
+        <updated>{{ plugin.date | rssDate }}</updated>
+        <id>{{ absolutePostUrl }}</id>
+        <author>
+          <name>{{ plugin.data.maintainer.name }}</name>
+        </author>
+        <content type="html">{{ '<p>' + plugin.data.description + '</p>' + plugin.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+      </entry>
+    {%- endfor %}
+  {%- endif -%}
+</feed>

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,17 @@
         "valid-url": "^1.0.9"
       }
     },
+    "@11ty/eleventy-plugin-rss": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.0.9.tgz",
+      "integrity": "sha512-2KlFwjEuYNhNjiWvJZ9m0TcLh+9cocw+S3bGx1HN4KIaqPXF3+SXXxZs3uGbj4Kz+X9XxExe/EC9Y8eH5BDCzA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "posthtml": "^0.13.0",
+        "posthtml-urls": "1.0.0"
+      }
+    },
     "@11ty/eleventy-plugin-syntaxhighlight": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-3.0.1.tgz",
@@ -181,6 +192,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "any-promise": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
+      "integrity": "sha1-gwtoCqflbzNFHUsEnzvYBESY7ic=",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -1891,6 +1908,12 @@
         }
       }
     },
+    "http-equiv-refresh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-1.0.0.tgz",
+      "integrity": "sha1-jsU4hmBCvl8/evpzfRmNlL6xsHs=",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -2285,6 +2308,12 @@
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-6.4.3.tgz",
       "integrity": "sha512-m1xSB10Ncu22NR3X0xdaqu/GvP1xadDCFYGqGgd6me8DAWjyA68BKE5DHJmSxw1CGsWPsX+Hj2v/87J2w/LvMQ=="
+    },
+    "list-to-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
+      "integrity": "sha1-yn3/ZAYGQzysdcvoRGrNhksVv28=",
+      "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -2768,6 +2797,12 @@
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
       "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
+      "dev": true
+    },
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
@@ -2898,6 +2933,43 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
+    "posthtml": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.13.1.tgz",
+      "integrity": "sha512-8aJZ63WYL9YsAZVcrIn6U0dSYbna7hcTceZjnbH7dilg01t4t3JDx0UovbhGFscFJg/++qhECCjGEQuJAqD7dA==",
+      "dev": true,
+      "requires": {
+        "posthtml-parser": "^0.4.2",
+        "posthtml-render": "^1.2.2"
+      }
+    },
+    "posthtml-parser": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.2.tgz",
+      "integrity": "sha512-BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.9.2"
+      }
+    },
+    "posthtml-render": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.2.3.tgz",
+      "integrity": "sha512-rGGayND//VwTlsYKNqdILsA7U/XP0WJa6SMcdAEoqc2WRM5QExplGg/h9qbTuHz7mc2PvaXU+6iNxItvr5aHMg==",
+      "dev": true
+    },
+    "posthtml-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-urls/-/posthtml-urls-1.0.0.tgz",
+      "integrity": "sha512-CMJ0L009sGQVUuYM/g6WJdscsq6ooAwhUuF6CDlYPMLxKp2rmCYVebEU+wZGxnQstGJhZPMvXsRhtqekILd5/w==",
+      "dev": true,
+      "requires": {
+        "http-equiv-refresh": "^1.0.0",
+        "list-to-array": "^1.1.0",
+        "parse-srcset": "^1.0.2",
+        "promise-each": "^2.2.0"
+      }
+    },
     "pretty": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
@@ -2946,6 +3018,15 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
+      }
+    },
+    "promise-each": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
+      "integrity": "sha1-M1MXTv8mlEgQN+BOAfd6oPttG2A=",
+      "dev": true,
+      "requires": {
+        "any-promise": "^0.1.0"
       }
     },
     "proto-list": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eleventy-plugin-svg-contents": "^0.7.0"
   },
   "devDependencies": {
+    "@11ty/eleventy-plugin-rss": "^1.0.9",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1"
   }
 }


### PR DESCRIPTION
Using the 11ty RSS plugin to add a simple feed for plugins. Since the Netlify CMS user info isn't available at build time, I used the plugin maintainer for the required `<author>` field. Other than that it's a pretty straightforward implementation of the plugin.